### PR TITLE
Implement Episode::fromArray. Bugfix EpisodeGuid::fromArray value.

### DIFF
--- a/src/Values/Episode.php
+++ b/src/Values/Episode.php
@@ -17,6 +17,16 @@ class Episode extends Serializable
     ) {
     }
 
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            title: Arr::get($data, 'title'),
+            guid: EpisodeGuid::fromArray(Arr::get($data, 'guid')),
+            enclosure: Enclosure::fromArray(Arr::get($data, 'enclosure')),
+            metadata: EpisodeMetadata::fromArray(Arr::get($data, 'metadata', [])),
+        );
+    }
+
     public static function fromXmlElement(Element $item): static
     {
         try {

--- a/src/Values/EpisodeGuid.php
+++ b/src/Values/EpisodeGuid.php
@@ -28,7 +28,7 @@ class EpisodeGuid extends Serializable
     public static function fromArray(array $data): static
     {
         return new static(
-            value: Arr::get($data, 'guid'),
+            value: Arr::get($data, 'value'),
             isPermaLink: Arr::get($data, 'is_perma_link'),
         );
     }


### PR DESCRIPTION
README says "Additionally, classes like Channel and **Episode** provide fromArray static methods to create instances from arrays. " but episode was missing it. This adds it. Also fixes a variable name in EpisodeGuid that is relied on.