### PR TITLE
Change scope of all Poddle class method to public

### DIFF
--- a/src/Poddle.php
+++ b/src/Poddle.php
@@ -88,7 +88,7 @@ class Poddle
      * @throws Throwable
      * @throws XmlReaderException
      */
-    private function getSoleValue(string ...$queries): ?string
+    public function getSoleValue(string ...$queries): ?string
     {
         try {
             foreach ($queries as $query) {
@@ -120,7 +120,7 @@ class Poddle
      * @throws Throwable
      * @throws XmlReaderException
      */
-    private function getMetadata(): ChannelMetadata
+    public function getMetadata(): ChannelMetadata
     {
         return new ChannelMetadata(
             locked: $this->getSoleValue('podcast:locked') === 'yes',
@@ -140,7 +140,7 @@ class Poddle
      * @throws Throwable
      * @throws XmlReaderException
      */
-    private function getFundings(): FundingCollection
+    public function getFundings(): FundingCollection
     {
         return FundingCollection::fromXmlElements(
             $this->xmlReader->element('rss.channel.podcast:funding')->collectLazy()
@@ -153,7 +153,7 @@ class Poddle
      * @throws Throwable
      * @throws XmlReaderException
      */
-    private function getCategories(): CategoryCollection
+    public function getCategories(): CategoryCollection
     {
         return CategoryCollection::fromXmlElements(
             $this->xmlReader->element('rss.channel.itunes:category')->collectLazy()
@@ -166,7 +166,7 @@ class Poddle
      * @throws Throwable
      * @throws XmlReaderException
      */
-    private function getTxts(): TxtCollection
+    public function getTxts(): TxtCollection
     {
         return TxtCollection::fromXmlElements(
             $this->xmlReader->element('rss.channel.podcast:txt')->collectLazy()

--- a/src/Values/Category.php
+++ b/src/Values/Category.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Category extends Serializable
 {
-    final public function __construct(public readonly string $text, public readonly ?Category $subCategory = null)
+    public function __construct(public readonly string $text, public readonly ?Category $subCategory = null)
     {
     }
 

--- a/src/Values/CategoryCollection.php
+++ b/src/Values/CategoryCollection.php
@@ -16,7 +16,7 @@ class CategoryCollection extends Collection
     /**
      * @param  array<TModel>  $items
      */
-    final public function __construct(array $items = [])
+    public function __construct(array $items = [])
     {
         parent::__construct($items);
     }

--- a/src/Values/Channel.php
+++ b/src/Values/Channel.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Arr;
 
 class Channel extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $url,
         public readonly string $title,
         public readonly string $description,

--- a/src/Values/ChannelMetadata.php
+++ b/src/Values/ChannelMetadata.php
@@ -7,7 +7,7 @@ use PhanAn\Poddle\Enums\PodcastType;
 
 class ChannelMetadata extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly bool $locked,
         public readonly ?string $guid,
         public readonly ?string $author,

--- a/src/Values/Enclosure.php
+++ b/src/Values/Enclosure.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Enclosure extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $url,
         public readonly string $type,
         public readonly int $length

--- a/src/Values/Episode.php
+++ b/src/Values/Episode.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Episode extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $title,
         public readonly EpisodeGuid $guid,
         public readonly Enclosure $enclosure,

--- a/src/Values/EpisodeCollection.php
+++ b/src/Values/EpisodeCollection.php
@@ -11,7 +11,7 @@ use Illuminate\Support\LazyCollection;
  */
 class EpisodeCollection extends LazyCollection
 {
-    final public function __construct($source = null)
+    public function __construct($source = null)
     {
         parent::__construct($source);
     }

--- a/src/Values/EpisodeGuid.php
+++ b/src/Values/EpisodeGuid.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class EpisodeGuid extends Serializable
 {
-    final public function __construct(public readonly string $value, public readonly bool $isPermaLink)
+    public function __construct(public readonly string $value, public readonly bool $isPermaLink)
     {
     }
 

--- a/src/Values/EpisodeMetadata.php
+++ b/src/Values/EpisodeMetadata.php
@@ -12,7 +12,7 @@ use Saloon\XmlWrangler\Data\Element;
 
 class EpisodeMetadata extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly ?string $link,
         public readonly ?DateTime $pubDate,
         public readonly ?string $description,

--- a/src/Values/Funding.php
+++ b/src/Values/Funding.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Funding extends Serializable
 {
-    final public function __construct(public readonly string $url, public readonly string $text)
+    public function __construct(public readonly string $url, public readonly string $text)
     {
     }
 

--- a/src/Values/FundingCollection.php
+++ b/src/Values/FundingCollection.php
@@ -16,7 +16,7 @@ class FundingCollection extends Collection
     /**
      * @param array<TModel> $items
      */
-    final public function __construct(array $items = [])
+    public function __construct(array $items = [])
     {
         parent::__construct($items);
     }

--- a/src/Values/Transcript.php
+++ b/src/Values/Transcript.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Transcript extends Serializable
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $url,
         public readonly string $type,
         public readonly ?string $language,

--- a/src/Values/TranscriptCollection.php
+++ b/src/Values/TranscriptCollection.php
@@ -15,7 +15,7 @@ class TranscriptCollection extends Collection
     /**
      * @param array<TModel> $items
      */
-    final public function __construct(array $items = [])
+    public function __construct(array $items = [])
     {
         parent::__construct($items);
     }

--- a/src/Values/Txt.php
+++ b/src/Values/Txt.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class Txt extends Serializable
 {
-    final public function __construct(public readonly string $content, public readonly ?string $purpose)
+    public function __construct(public readonly string $content, public readonly ?string $purpose)
     {
     }
 

--- a/src/Values/TxtCollection.php
+++ b/src/Values/TxtCollection.php
@@ -16,7 +16,7 @@ class TxtCollection extends Collection
     /**
      * @param array<TModel> $items
      */
-    final public function __construct(array $items = [])
+    public function __construct(array $items = [])
     {
         parent::__construct($items);
     }


### PR DESCRIPTION
This goes a little of the way to help handling this issue https://github.com/phanan/poddle/issues/5

I don't see a reason why none of these methods cant be accessible outside of the Poddle class